### PR TITLE
Add more logs and a switch hhvm.server.thread_job_abort_with_conn_closed

### DIFF
--- a/hphp/runtime/base/program-functions.cpp
+++ b/hphp/runtime/base/program-functions.cpp
@@ -449,10 +449,8 @@ static void handle_exception_helper(bool& ret,
   } catch (const ScriptAbortForConnClosedException &e) {
     ret = false;
     error = true;
-    Logger::LogHeader = true;
     errorMsg = e.what();
     Logger::Warning("%s", errorMsg.c_str());
-    Logger::LogHeader = false;
   } catch (const Exception &e) {
     bool oldRet = ret;
     bool origError = error;

--- a/hphp/runtime/base/runtime-option.cpp
+++ b/hphp/runtime/base/runtime-option.cpp
@@ -140,6 +140,7 @@ bool RuntimeOption::ServerThreadRoundRobin = false;
 int RuntimeOption::ServerWarmupThrottleRequestCount = 0;
 int RuntimeOption::ServerThreadDropCacheTimeoutSeconds = 0;
 int RuntimeOption::ServerThreadJobLIFOSwitchThreshold = INT_MAX;
+int RuntimeOption::ThreadJobAbortWithConnClosed = false;
 int RuntimeOption::ServerThreadJobMaxQueuingMilliSeconds = -1;
 bool RuntimeOption::ServerThreadDropStack = false;
 bool RuntimeOption::ServerHttpSafeMode = false;
@@ -1086,6 +1087,9 @@ void RuntimeOption::Load(IniSetting::Map& ini, Hdf& config,
     Config::Bind(ServerThreadJobLIFOSwitchThreshold, ini,
                  server["ThreadJobLIFOSwitchThreshold"],
                  ServerThreadJobLIFOSwitchThreshold);
+    Config::Bind(ThreadJobAbortWithConnClosed, ini,
+                 server["ThreadJobAbortWithConnClosed"],
+                 ThreadJobAbortWithConnClosed);
     Config::Bind(ServerThreadJobMaxQueuingMilliSeconds, ini,
                  server["ThreadJobMaxQueuingMilliSeconds"], -1);
     Config::Bind(ServerThreadDropStack, ini, server["ThreadDropStack"]);

--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -121,6 +121,7 @@ public:
   static bool ServerThreadRoundRobin;
   static int ServerThreadDropCacheTimeoutSeconds;
   static int ServerThreadJobLIFOSwitchThreshold;
+  static int ThreadJobAbortWithConnClosed;
   static int ServerThreadJobMaxQueuingMilliSeconds;
   static bool ServerThreadDropStack;
   static bool ServerHttpSafeMode;

--- a/hphp/runtime/server/fastcgi/fastcgi-session.cpp
+++ b/hphp/runtime/server/fastcgi/fastcgi-session.cpp
@@ -231,6 +231,8 @@ void FastCGISession::dropConnection() {
   }
 
   m_sock->closeWithReset();
+  Logger::Warning("Connection(User: %s:%d) closed with reset.",
+    m_transport->getRemoteAddr(), m_transport->getRemotePort());
 }
 
 void FastCGISession::dumpConnectionState(uint8_t loglevel) { /* nop */ }
@@ -486,6 +488,8 @@ void FastCGISession::onRecordImpl(const fcgi::abort_record* rec) {
   }
 
   /**/
+  Logger::Warning("Connection(User: %s:%d) received user abort request.",
+    m_transport->getRemoteAddr(), m_transport->getRemotePort());
   m_transport->setConnTobeClosed();
 
   writeEndRequest(m_requestId, 1, fcgi::REQUEST_COMPLETE);

--- a/hphp/runtime/server/transport.h
+++ b/hphp/runtime/server/transport.h
@@ -421,7 +421,8 @@ public:
   bool isSSL() const {return m_isSSL;}
 
   void setConnTobeClosed() {conn_tobeclosed= true;}
-  bool isConnTobeClosed() const {return conn_tobeclosed;}
+  bool isConnTobeClosed() const
+  {return RuntimeOption::ThreadJobAbortWithConnClosed && conn_tobeclosed;}
 
 protected:
   /**


### PR DESCRIPTION
1.remove Logger::LogHeader set before logging
2.write log when receiving user abort request and closing connection with reset
3.add a switch hhvm.server.thread_job_abort_with_conn_closed